### PR TITLE
ci: changesets version via npx + VERSION sync inline

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -36,7 +36,9 @@ jobs:
           node-version: "20"
       - uses: changesets/action@v1
         with:
-          version: npm run --silent version:changesets
+          version: |
+            npx -y @changesets/cli@^2.27.9 changeset version
+            node -e "const fs=require('fs');const v=require('./package.json').version;fs.writeFileSync('VERSION', v+'\n');require('child_process').execSync('git add VERSION',{stdio:'inherit'})"
           commit: "chore: version packages"
           title: "Version Packages"
         env:


### PR DESCRIPTION
Avoid npm run exit ambiguity; invoke npx changeset version and sync VERSION in a separate node command.