### PR TITLE
ci: use script for changeset version + VERSION sync

### DIFF
--- a/.github/scripts/version-and-sync.cjs
+++ b/.github/scripts/version-and-sync.cjs
@@ -1,0 +1,23 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+
+function run(cmd) {
+  execSync(cmd, { stdio: 'inherit', env: process.env });
+}
+
+// 1) Version packages via Changesets
+run('npx -y @changesets/cli@^2.27.9 changeset version');
+
+// 2) Sync canonical VERSION from package.json
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+const next = (pkg.version || '').trim();
+if (!next) {
+  console.error('No version found in package.json');
+  process.exit(1);
+}
+fs.writeFileSync('VERSION', `${next}\n`, 'utf8');
+
+// 3) Stage VERSION so the action commits it
+run('git add VERSION');
+
+

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -36,9 +36,7 @@ jobs:
           node-version: "20"
       - uses: changesets/action@v1
         with:
-          version: |
-            npx -y @changesets/cli@^2.27.9 changeset version
-            node -e "const fs=require('fs');const v=require('./package.json').version;fs.writeFileSync('VERSION', v+'\n');require('child_process').execSync('git add VERSION',{stdio:'inherit'})"
+          version: node .github/scripts/version-and-sync.cjs
           commit: "chore: version packages"
           title: "Version Packages"
         env:


### PR DESCRIPTION
Adds .github/scripts/version-and-sync.cjs and updates workflow to call it. Please enable Actions: Read and write permissions and allow creating PRs so the action can open the Version Packages PR.