### PR TITLE
docs(ai-workflow-integration): clarify slash precedence, add /analyze gate, define next-task selection

### DIFF
--- a/docs/projects/ai-workflow-integration/comparison-framework.md
+++ b/docs/projects/ai-workflow-integration/comparison-framework.md
@@ -8,27 +8,35 @@ Evaluate `ai-dev-tasks`, `spec-kit`, and `claude-task-master` to inform targeted
 
 - Setup & Integration
   - How does it install/configure? Any editor/CLI coupling?
-  - Slash‑commands support (agent exposure), optionality, and portability
+  - Slash‑commands support (agent exposure), optionality, portability, and phrase‑trigger fallback
 - Artifacts & Templates
   - PRD/ERD structure and prompts; plan/tasks linkage
   - Two‑phase task flow; clarity for junior developers
+  - Cross‑linking between spec/plan/tasks at file tops
 - Tasks Model
   - Dependencies and priority semantics; parallelizable markers `[P]`
   - Relevant files discipline and TDD coupling
+- Decision Gates & Uncertainty
+  - Uncertainty markers in ERDs; `/analyze` gate before implementation
 - Logging & Progress
   - Reflective logs vs runtime logging; operational metrics (elapsed, token I/O)
-  - Redaction/privacy safeguards; storage locations
+  - Redaction/privacy safeguards; storage locations (docs‑only)
+- Acceptance & Validation
+  - Clear acceptance checks; ease of spot‑checks and dry‑runs
 - Licensing & Reuse
   - License compatibility; what to borrow (citations) vs re‑implement
 - Configuration & Toggles
-  - Minimal, opt‑in flags; sensible defaults; no behavioral regressions
+  - Opt‑in flags via `.cursor/config.json` with unchanged defaults vs unified defaults; regression risk
+- Rollout & Ops Readiness
+  - Phased rollout complexity; reversibility; documentation/communication needs
 
 ## Artifacts to Produce
 
 - ERD (done)
-- Updated `tasks.md` with sub‑tasks and dependencies/priority markers (optional)
+- Updated `tasks.md` with sub‑tasks and dependencies/priority markers (optional) and cross‑link headers
 - Proposed rule diffs (paths + short descriptions)
 - Logging enhancements outline (Operation block + Dependency Impact)
+- Acceptance checks outline for a demo dry‑run
 
 ## Decision Notes
 

--- a/docs/projects/ai-workflow-integration/discussions.md
+++ b/docs/projects/ai-workflow-integration/discussions.md
@@ -52,8 +52,8 @@ Anchors
 
 Unified Workflow
 
-- Slash‑commands are first‑class: `/specify`, `/clarify`, `/plan`, `/tasks`, `/analyze`, `/implement`.
-- Tasks include `dependencies`, `priority`, and optional `[P]` for parallelization.
+- Slash‑commands are first‑class (optional): `/constitution`, `/specify`, `/clarify`, `/plan`, `/tasks`, `/analyze`, `/implement` (slash > phrase precedence).
+- Tasks include `dependencies`, `priority`, and optional `[P]` for parallelization (different‑file tasks only; group safe parallel sets in tasks.md).
 - Learning logs include an Operation block and Dependency Impact by default (values may be N/A if not available).
 
 Out of Scope (initial)
@@ -96,7 +96,7 @@ Out of Scope (initial)
 
   3.3 `/analyze` gate
 
-- Add a brief analysis step before `/implement` to validate coverage/consistency across ERD/plan/tasks.
+- Add a brief analysis step before `/implement` to validate coverage/consistency across ERD/plan/tasks. Trigger expansion when shared‑file coupling is high or sub‑task count > N; record "why expand".
 
   3.4 `constitution.md` feasibility
 
@@ -111,7 +111,7 @@ Out of Scope (initial)
 
   4.2 Minimal additions to `generate-tasks-from-erd.mdc`
 
-- Keep two‑phase flow; add a short optional note explaining deps/priority fields and when to use them.
+- Keep two‑phase flow; add a short optional note explaining deps/priority fields and when to use them. Define next‑task selection: highest‑priority unblocked; tie → shortest critical path.
 
   4.3 Operational metrics patterns (`src/progress/*`, `mcp-server/src/logger.js`)
 
@@ -185,6 +185,7 @@ Schema additions
 - ReviewAfter: YYYY-MM-DD (schedule follow-up)
 - Operation: Elapsed, TokenIn, TokenOut, Units; optional SamplesReviewed, CoverageDelta
 - Dependency Impact: RulesAffected, DocsAffected, AffectedTasks, Unblocked, Added/Removed
+- Research Notes: one‑line summary when research ping used before a risky sub‑task
 
 Storage & persistence
 

--- a/docs/projects/ai-workflow-integration/erd.md
+++ b/docs/projects/ai-workflow-integration/erd.md
@@ -31,6 +31,7 @@ Unify and improve our Cursor Rules by integrating proven workflows from three so
 1. ERD Creation
 
    - Add explicit uncertainty markers: `[NEEDS CLARIFICATION: …]` when inputs are ambiguous.
+   - Include a brief, numbered Clarifications section; resolve or explicitly defer items before `/implement`.
    - Optionally recognize slash‑commands (`/specify`, `/clarify`, `/plan`) in addition to phrase triggers.
    - Output path remains `docs/projects/<feature>/erd.md`.
 
@@ -49,7 +50,7 @@ Unify and improve our Cursor Rules by integrating proven workflows from three so
 
 4. Spec‑Driven Workflow Integration
 
-   - Document optional slash‑commands: `/specify`, `/clarify`, `/plan`, `/tasks`, `/analyze`, `/implement`.
+   - Document optional slash‑commands: `/specify`, `/clarify`, `/plan`, `/tasks`, `/analyze`, `/implement` (slash takes precedence over phrases when present).
    - Add an analysis gate before implementation (Spec Kit `/analyze`).
    - Cross‑link artifacts (spec/plan/tasks) at file tops.
 
@@ -59,11 +60,12 @@ Unify and improve our Cursor Rules by integrating proven workflows from three so
    - Add “Dependency Impact” notes: which tasks/sections were affected.
    - Respect redaction and fallback directories.
 
-6. Unified Defaults (No Toggles)
+6. Defaults & Configuration
 
-- Slash‑commands recognized by default; phrase triggers remain supported.
-- Tasks support `dependencies`, `priority`, and `[P]` markers by default.
-- Self‑improvement logging is always on via `logging-protocol.mdc` with Operation and Dependency Impact sections.
+- Defaults remain unchanged by default; features are opt‑in via `.cursor/config.json`.
+- Slash‑commands may be enabled as an option; phrase triggers remain supported.
+- Tasks may include optional `dependencies`, `priority`, and `[P]` markers.
+- Self‑improvement logging retains current behavior; optional Operation/Dependency Impact can be enabled.
 
 ## 5. Non-Functional Requirements
 
@@ -110,8 +112,9 @@ Unify and improve our Cursor Rules by integrating proven workflows from three so
 
 - Acceptance (docs-level):
   - Creating a new ERD triggers uncertainty markers when prompts are ambiguous.
+  - Clarifications section exists; either cleared or explicitly deferred with rationale before `/implement`.
   - Generating tasks (phase 1) yields only parent tasks; phase 2 adds sub‑tasks.
-  - Task‑list process enforces one‑sub‑task gating and dependency‑aware next selection.
+  - Task‑list process enforces one‑sub‑task gating and dependency‑aware next selection (highest‑priority unblocked; tie → shortest critical path).
   - Logging entries include the Operation block (best‑effort) and Dependency Impact.
   - Spec‑driven rule lists slash‑commands and `/analyze` gate.
 - Spot checks:

--- a/docs/projects/ai-workflow-integration/tasks.md
+++ b/docs/projects/ai-workflow-integration/tasks.md
@@ -14,6 +14,10 @@
 ### Notes
 
 - Optional fields (dependencies/priority/[P]) are additive and controlled by feature flags.
+- Next-task selection: choose highest‑priority unblocked task; on ties, prefer shortest critical path.
+- Parallelization `[P]`: mark only when tasks touch different files; include a short "safe parallel groups" note when applicable.
+- Research ping: for risky or unfamiliar sub‑tasks, do a brief research step and add a one‑line "Research notes" summary here.
+- Evidence-based completion: mark a sub‑task complete only after tests pass and lint/type checks are clean (manual override: docs‑only/emergency).
 
 ## Tasks
 


### PR DESCRIPTION
## Summary
Clarifies slash-command precedence, adds an /analyze gate, defines next-task selection, tightens [P] usage, and adds research/acceptance notes.

## Changes
- **comparison-framework**: decision gates & uncertainty; acceptance checks outline; config toggles vs unified defaults; rollout/ops readiness.
- **discussions**: slash>phrase precedence; [P] only for different-file tasks + grouping guidance; /analyze expansion triggers and record why; next-task selection (highest-priority unblocked; tie -> shortest critical path); Research Notes field.
- **erd**: Clarifications section + require resolve/defer before /implement; note slash precedence; opt-in features via .cursor/config.json; acceptance updated.
- **tasks**: next-task rule; [P] different-file constraint + safe parallel groups note; research ping + one-line notes; evidence-based completion criteria.

## Why
- Improves clarity and consistency across ERD/plan/tasks.
- Adds a safety check before implementation for high-coupling/large task sets.
- Makes parallelization explicit and safer.

## Acceptance & Validation
- Clarifications section present and resolved/deferred before /implement.
- Two-phase tasks; next-task rule applied; [P] only when tasks touch different files.
- Logging includes Operation + Dependency Impact; add Research Notes when a research ping is used.
- Cross-links at file tops (spec/plan/tasks).

## Follow-ups
- Decide defaults in .cursor/config.json for slash-command recognition and optional logging fields.
- Add demo dry-run acceptance checks outline to comparison-framework.