### PR TITLE
chore: intent-routing docs and tasks improvements

### DIFF
--- a/.cursor/rules/intent-routing.mdc
+++ b/.cursor/rules/intent-routing.mdc
@@ -73,10 +73,23 @@ This lightweight router keeps context minimal by attaching specific rules only w
     - Prefer: include "for <feature>"; if missing and ambiguous, ask for the feature name
   - Attach: `create-erd.mdc`, `guidance-first.mdc`
 
+- Planning / Specification
+
+  - Triggers: <verb> + <plan-term>
+    - Verbs: plan|specify|analyze|outline|draft
+    - Plan terms: plan|spec|specification|analysis|acceptance bundle
+  - Attach: `spec-driven.mdc`, `guidance-first.mdc`
+
 - Task lists
   - Triggers: task list phrases
     - Terms: task list|update tasks|mark sub-task|mark subtask|check off|relevant files section
   - Attach: `task-list-process.mdc`
+
+## Slash commands
+
+- `/plan <topic>` → route to `spec-driven.mdc` (plan/specify); consent-first; produce plan scaffold
+- `/tasks` → route to `task-list-process.mdc`; manage/update tasks non-interactively when safe
+- `/pr` → route to `assistant-git-usage.mdc`; prefer `.cursor/scripts/pr-create.sh` with explicit consent and non-interactive flags
 
 ## File/context signals (supporting)
 
@@ -85,8 +98,7 @@ This lightweight router keeps context minimal by attaching specific rules only w
 - On implementation verbs (implement/add/fix/refactor/update), attach testing + TDD by default (see `user-intent.mdc`).
 - JS/TS pre-edit gate: If the next step targets JS/TS files (`*.ts|*.tsx|*.js|*.mjs|*.cjs`), attach a minimal TDD checklist and enforce tests-first before edits. Load full `testing.mdc` progressively when test authoring or failures occur.
   - Enforcement: block edits until the TDD confirmation is present (see Assistant Behavior rule).
-- If any focused/open/edited path matches `**/tasks/*.md`, attach `assistant-git-usage.mdc`.
-- If any focused/open/edited path matches `**/tasks/*.md`, attach `task-list-process.mdc`.
+- If any focused/open/edited path matches `**/tasks/*.md`, attach `assistant-git-usage.mdc`, `task-list-process.mdc`.
 
 ## Decision policy (weights)
 
@@ -98,6 +110,11 @@ This lightweight router keeps context minimal by attaching specific rules only w
 5. If still ambiguous and intent suggests implementation, attach testing + TDD and ask one clarifying question
 
 - If ambiguity persists after one clarifying question, do not attach additional rules and pause.
+
+### Role–phase and split-progress advisory
+
+- Prefer phase-consistent routing: when a project is in a planning phase, route “what/why” requests to `spec-driven` over implementation rules.
+- Consult split-progress status (if available) to decide between plan vs implement; when unavailable, ask one clarifying question.
 
 ## Fuzzy matching & confirmation
 
@@ -141,6 +158,22 @@ This lightweight router keeps context minimal by attaching specific rules only w
 - If multiple triggers match, attach the union (deduplicated).
 - Status transparency: In status updates, include which signal triggered routing (e.g., explicit verb, consent-after-plan, file signal) for traceability.
 - Logging: For routing corrections or guard triggers, write a brief Assistant Learning Log via `.cursor/scripts/alp-logger.sh write-with-fallback assistant-logs "routing-correction" <<'BODY' … BODY`.
+
+## Handoff contract
+
+Router outputs a normalized context object for downstream rules:
+
+```json
+{
+  "intent": "implement|plan|refactor|guidance|git|tasks|erd",
+  "targets": ["file paths or feature names"],
+  "rule": "tdd-first|spec-driven|assistant-git-usage|task-list-process|cursor-platform-capabilities",
+  "gates": ["consent", "tdd-owner-spec"],
+  "consentState": "required|granted|not-applicable"
+}
+```
+
+Callees must respect `gates` and update `consentState` as they proceed.
 
 Related
 

--- a/docs/projects/README.md
+++ b/docs/projects/README.md
@@ -32,6 +32,7 @@ A landing page for all projects, grouped by status.
 - [spec-driven](./spec-driven/erd.md) — Phased workflow: Specify → Plan → Tasks with deterministic artifacts and rules.
 - [split-progress](./split-progress/erd.md) — Index of split ERDs with owners, statuses, tasks, and dependencies.
 - [tdd-first](./tdd-first/erd.md) — Enforce Red → Green → Refactor with owner specs and effects seams.
+- [project-erd-front-matter](./project-erd-front-matter/erd.md) — Minimal ERD front matter placeholder for future follow-up.
 
 ## Completed
 

--- a/docs/projects/intent-router/tasks.md
+++ b/docs/projects/intent-router/tasks.md
@@ -3,10 +3,28 @@
 ## Relevant Files
 
 - `docs/projects/intent-router/erd.md`
-- `.cursor/rules/intent-router.mdc`
+- `.cursor/rules/intent-routing.mdc`
 
 ## Todo
 
 - [x] 1.0 Draft ERD skeleton with parsing/routing/gates
-- [ ] 2.0 Add example parses and clarify-on-ambiguity policy
-- [ ] 3.0 Link ERD from README and progress doc
+- [x] 2.0 Add example parses and clarify-on-ambiguity policy
+- [x] 3.0 Link ERD from README and progress doc
+- [x] 4.0 Maintain ERD "Last updated" date on future edits
+
+## Gaps — Actionable
+
+- [x] Document slash commands routing in `.cursor/rules/intent-routing.mdc` (cover `/plan`, `/tasks`, `/pr` mapping and consent gates)
+- [x] Define router handoff contract shape in `.cursor/rules/intent-routing.mdc` (`{intent, targets, rule, gates, consentState}`) and reference in Integration Points
+- [x] Add advisory note on role–phase mapping and split-progress prioritization in `.cursor/rules/intent-routing.mdc`
+- [x] Add explicit trigger mapping for plan/specify/analyze → `spec-driven` in `.cursor/rules/intent-routing.mdc`
+- [x] Remove duplicated `**/tasks/*.md` signal line in `.cursor/rules/intent-routing.mdc`
+
+## Gaps — Blocked
+
+- [ ] Add drawing-board triggers and integration notes in `.cursor/rules/intent-routing.mdc`
+  - Blocked by: complete `docs/projects/drawing-board/erd.md` and its corresponding rule
+- [ ] Implement automated enforcement for role–phase mapping and split-progress within routing decisions
+  - Blocked by: complete `docs/projects/role-phase-mapping/erd.md` and `docs/projects/split-progress/erd.md`
+- [ ] Support slash command runtime handling (execution semantics beyond documentation)
+  - Blocked by: create and complete a new project for slash-commands runtime (e.g., `docs/projects/slash-commands/erd.md`)

--- a/docs/projects/project-erd-front-matter/erd.md
+++ b/docs/projects/project-erd-front-matter/erd.md
@@ -1,0 +1,43 @@
+---
+status: active
+owner: rules-maintainers
+lastUpdated: 2025-10-05
+---
+
+# Engineering Requirements Document — Project ERD Front Matter (Lite)
+
+## Purpose
+
+Standardize minimal ERD front matter across projects for consistency and lifecycle alignment.
+
+## Standard
+
+- Required:
+  - `status`: `active` | `completed`
+  - `owner`: project owner or team
+  - `lastUpdated`: YYYY-MM-DD
+- Optional (when closing):
+  - `completed`: YYYY-MM-DD (set when `status: completed`)
+
+## Examples
+
+Active:
+
+```yaml
+---
+status: active
+owner: rules-maintainers
+lastUpdated: 2025-10-05
+---
+```
+
+Completed:
+
+```yaml
+---
+status: completed
+completed: 2025-10-31
+owner: rules-maintainers
+lastUpdated: 2025-10-31
+---
+```


### PR DESCRIPTION
## Summary
Briefly describe what this PR changes and why.

## Changes
- High-level bullets of what changed

## Why
What problem does this solve? Any alternatives considered?

## Acceptance & Validation
- [ ] Local checks pass (lint/type/tests as applicable)
- [ ] Docs updated (README/rules/specs as applicable)
- [ ] Acceptance criteria below are met

### Acceptance checks (copy/paste)
- [ ] <behavior/outcome 1>
- [ ] <behavior/outcome 2>

## Risk & Rollout
- Impact/backwards compatibility
- Migration/revert plan
- Rollout/communication notes

## Screenshots / Docs
Links or images (if UI or docs impact)

## Related
Closes #<issue>, Relates to #<issue>, Follow-ups\n\n## Context\nSummary: update intent-routing rule docs and tasks | Changes: slash command routing, handoff contract, split-progress advisory, task list updates, learning log | Why: align rule with ERD and improve task hygiene | Acceptance: rule lint clean, tasks updated, log added | Risk & Rollout: low\n